### PR TITLE
use webmidi instead of midi module

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
   "homepage": "https://github.com/nathanielkornet/visuals#readme",
   "dependencies": {
     "express": "^4.15.3",
-    "midi": "^0.9.5",
     "quickhull3d": "^2.0.0",
     "socket.io": "^2.0.3",
     "socket.io-client": "^2.0.3",
-    "three": "^0.85.2"
+    "three": "^0.85.2",
+    "webmidi": "^2.0.0-rc.5"
   },
   "devDependencies": {
     "@dlmanning/bind": "^1.0.0",

--- a/src/midi-interface/index.js
+++ b/src/midi-interface/index.js
@@ -1,5 +1,3 @@
-import Midi from 'midi'
-
 const emptyBindings = {
   K: {}, // knobs
   F: {}, // faders
@@ -15,16 +13,21 @@ const emptyBindings = {
 // conditionally required
 module.exports = class MidiInterface {
   constructor () {
-    // Set up a new input.
-    const input = new Midi.input()
+    const webmidi = require('webmidi')
+    webmidi.enable(err => {
+      if (err) console.error(err)
 
-    if (input.getPortCount() > 0) {
-      // set to parse message on receipt
-      input.on('message', (deltaTime, message) => this.parseMessage(message))
-
-      // open the first available input port
-      input.openPort(0)
-    }
+      const input = webmidi.inputs[1]
+      input.addListener('controlchange', 'all', ev => {
+        this.parseMessage(ev.data)
+      })
+      input.addListener('noteon', 'all', ev => {
+        this.parseMessage(ev.data)
+      })
+      input.addListener('noteoff', 'all', ev => {
+        this.parseMessage(ev.data)
+      })
+    })
 
     // store of onChange handlers
     this.bindings = emptyBindings


### PR DESCRIPTION
was having problems with `midi`. the package hasn't been updated in two years so switching to `webmidi` as that seems to be in active development. provides the same functionality.